### PR TITLE
Added clients/workspaces syncing on window focus change

### DIFF
--- a/src/service/hyprland.ts
+++ b/src/service/hyprland.ts
@@ -337,11 +337,17 @@ export class Hyprland extends Service {
                 case 'activewindow':
                     this._active.client.updateProperty('class', argv[0]);
                     this._active.client.updateProperty('title', argv.slice(1).join(','));
+                    await this._syncClients(false);
+                    await this._syncWorkspaces(false);
+                    ['clients', 'workspaces'].forEach(e => this.notify(e));
                     this._active.client.emit('changed');
                     break;
 
                 case 'activewindowv2':
                     this._active.client.updateProperty('address', '0x' + argv[0]);
+                    await this._syncClients(false);
+                    await this._syncWorkspaces(false);
+                    ['clients', 'workspaces'].forEach(e => this.notify(e));
                     this._active.client.emit('changed');
                     break;
 


### PR DESCRIPTION
Hyprland service: added sync for clients and workspaces properties on reception of both activewindow and activewindowv2 signals